### PR TITLE
[WIP] Feat: partitionByNewLine + partitionByComment

### DIFF
--- a/docs/content/rules/sort-classes.mdx
+++ b/docs/content/rules/sort-classes.mdx
@@ -189,7 +189,8 @@ Allows you to use comments to separate the class members into logical groups. Th
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
-- string — A glob pattern to specify which comments should act as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
 
 ### groups
 

--- a/docs/content/rules/sort-enums.mdx
+++ b/docs/content/rules/sort-enums.mdx
@@ -140,7 +140,29 @@ Allows you to use comments to separate the members of enums into logical groups.
 
 - `true` — All comments will be treated as delimiters, creating partitions.
 -	`false` — Comments will not be used as delimiters.
-- string — A glob pattern to specify which comments should act as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of an enum if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+enum Enum {
+  // Group 1
+  C = 'C',
+  D = 'D',
+
+  // Group 2
+  B = 'B',
+
+  // Group 3
+  A = 'A',
+  E = 'E',
+}
+```
 
 ## Usage
 
@@ -164,7 +186,9 @@ Allows you to use comments to separate the members of enums into logical groups.
                   order: 'asc',
                   ignoreCase: true,
                   partitionByComment: false,
-                  sortByValue: false
+                  partitionByNewLine: false,
+                  sortByValue: false,
+                  forceNumericSort: false
                 },
               ],
             },
@@ -189,6 +213,7 @@ Allows you to use comments to separate the members of enums into logical groups.
                 order: 'asc',
                 ignoreCase: true,
                 partitionByComment: false,
+                partitionByNewLine: false,
                 sortByValue: false,
                 forceNumericSort: false
               },

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -123,6 +123,17 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### partitionByComment
+
+<sub>default: `false`</sub>
+
+Allows you to use comments to separate the members of types into logical groups. This can help in organizing and maintaining large enums by creating partitions within the enum based on comments.
+
+- `true` — All comments will be treated as delimiters, creating partitions.
+- `false` — Comments will not be used as delimiters.
+- `string` — A glob pattern to specify which comments should act as delimiters.
+- `string[]` — A list of glob patterns to specify which comments should act as delimiters.
+
 ### partitionByNewLine
 
 <sub>default: `false`</sub>
@@ -215,6 +226,7 @@ Example:
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByComment: false,
                   partitionByNewLine: false,
                   groups: [],
                   customGroups: {},
@@ -241,6 +253,7 @@ Example:
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByComment: false,
                 partitionByNewLine: false,
                 groups: [],
                 customGroups: {},

--- a/docs/content/rules/sort-object-types.mdx
+++ b/docs/content/rules/sort-object-types.mdx
@@ -127,7 +127,7 @@ Controls whether sorting should be case-sensitive or not.
 
 <sub>default: `false`</sub>
 
-When `true`, the rule will not sort the members of an interface if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+When `true`, the rule will not sort the members of any object if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
 
 ```ts
 type User = {

--- a/docs/content/rules/sort-switch-case.mdx
+++ b/docs/content/rules/sort-switch-case.mdx
@@ -174,6 +174,32 @@ Controls whether sorting should be case-sensitive or not.
 - `true` — Ignore case when sorting alphabetically or naturally (e.g., “A” and “a” are the same).
 - `false` — Consider case when sorting (e.g., “A” comes before “a”).
 
+### partitionByNewLine
+
+<sub>default: `false`</sub>
+
+When `true`, the rule will not sort the members of an enum if there is an empty line between them. This can be useful for keeping logically separated groups of members in their defined order.
+
+```ts
+switch (action) {
+     // Group 1
+    case 'Drone':
+    case 'Keyboard':
+    case 'Mouse':
+    case 'Smartphone':
+
+    // Group 2
+    case 'Laptop':
+    case 'Monitor':
+    case 'Smartwatch':
+    case 'Tablet':
+
+    // Group 3
+    case 'Headphones':
+    case 'Router':
+}
+```
+
 ## Usage
 
 <CodeTabs
@@ -195,6 +221,7 @@ Controls whether sorting should be case-sensitive or not.
                   type: 'alphabetical',
                   order: 'asc',
                   ignoreCase: true,
+                  partitionByNewLine: false
                 },
               ],
             },
@@ -218,6 +245,7 @@ Controls whether sorting should be case-sensitive or not.
                 type: 'alphabetical',
                 order: 'asc',
                 ignoreCase: true,
+                partitionByNewLine: false
               },
             ],
           },

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -187,47 +187,46 @@ export let sortArray = <MessageIds extends string>(
       [[]],
     )
 
-    for (let nodes of formattedMembers) {
-      pairwise(nodes, (left, right) => {
-        let groupKindOrder = ['unknown']
+    let nodes = formattedMembers.flat()
+    pairwise(nodes, (left, right) => {
+      let groupKindOrder = ['unknown']
 
-        if (typeof options.groupKind === 'string') {
-          groupKindOrder =
-            options.groupKind === 'literals-first'
-              ? ['literal', 'spread']
-              : ['spread', 'literal']
-        }
-        let leftNum = getGroupNumber(groupKindOrder, left)
-        let rightNum = getGroupNumber(groupKindOrder, right)
+      if (typeof options.groupKind === 'string') {
+        groupKindOrder =
+          options.groupKind === 'literals-first'
+            ? ['literal', 'spread']
+            : ['spread', 'literal']
+      }
+      let leftNum = getGroupNumber(groupKindOrder, left)
+      let rightNum = getGroupNumber(groupKindOrder, right)
 
-        if (
-          (options.groupKind !== 'mixed' && leftNum > rightNum) ||
-          ((options.groupKind === 'mixed' || leftNum === rightNum) &&
-            isPositive(compare(left, right, options)))
-        ) {
-          context.report({
-            messageId,
-            data: {
-              left: toSingleLine(left.name),
-              right: toSingleLine(right.name),
-            },
-            node: right.node,
-            fix: fixer => {
-              let sortedNodes =
-                options.groupKind !== 'mixed'
-                  ? groupKindOrder
-                      .map(group => nodes.filter(n => n.group === group))
-                      .map(groupedNodes => sortNodes(groupedNodes, options))
-                      .flat()
-                  : sortNodes(nodes, options)
+      if (
+        (options.groupKind !== 'mixed' && leftNum > rightNum) ||
+        ((options.groupKind === 'mixed' || leftNum === rightNum) &&
+          isPositive(compare(left, right, options)))
+      ) {
+        context.report({
+          messageId,
+          data: {
+            left: toSingleLine(left.name),
+            right: toSingleLine(right.name),
+          },
+          node: right.node,
+          fix: fixer => {
+            let sortedNodes =
+              options.groupKind !== 'mixed'
+                ? groupKindOrder
+                    .map(group => nodes.filter(n => n.group === group))
+                    .map(groupedNodes => sortNodes(groupedNodes, options))
+                    .flat()
+                : sortNodes(nodes, options)
 
-              return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-                partitionComment,
-              })
-            },
-          })
-        }
-      })
-    }
+            return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+              partitionComment,
+            })
+          },
+        })
+      }
+    })
   }
 }

--- a/rules/sort-array-includes.ts
+++ b/rules/sort-array-includes.ts
@@ -187,46 +187,46 @@ export let sortArray = <MessageIds extends string>(
       [[]],
     )
 
-    let nodes = formattedMembers.flat()
-    pairwise(nodes, (left, right) => {
-      let groupKindOrder = ['unknown']
+    for (let nodes of formattedMembers) {
+      pairwise(nodes, (left, right) => {
+        let groupKindOrder = ['unknown']
+        if (typeof options.groupKind === 'string') {
+          groupKindOrder =
+            options.groupKind === 'literals-first'
+              ? ['literal', 'spread']
+              : ['spread', 'literal']
+        }
+        let leftNum = getGroupNumber(groupKindOrder, left)
+        let rightNum = getGroupNumber(groupKindOrder, right)
 
-      if (typeof options.groupKind === 'string') {
-        groupKindOrder =
-          options.groupKind === 'literals-first'
-            ? ['literal', 'spread']
-            : ['spread', 'literal']
-      }
-      let leftNum = getGroupNumber(groupKindOrder, left)
-      let rightNum = getGroupNumber(groupKindOrder, right)
+        if (
+          (options.groupKind !== 'mixed' && leftNum > rightNum) ||
+          ((options.groupKind === 'mixed' || leftNum === rightNum) &&
+            isPositive(compare(left, right, options)))
+        ) {
+          context.report({
+            messageId,
+            data: {
+              left: toSingleLine(left.name),
+              right: toSingleLine(right.name),
+            },
+            node: right.node,
+            fix: fixer => {
+              let sortedNodes =
+                options.groupKind !== 'mixed'
+                  ? groupKindOrder
+                      .map(group => nodes.filter(n => n.group === group))
+                      .map(groupedNodes => sortNodes(groupedNodes, options))
+                      .flat()
+                  : sortNodes(nodes, options)
 
-      if (
-        (options.groupKind !== 'mixed' && leftNum > rightNum) ||
-        ((options.groupKind === 'mixed' || leftNum === rightNum) &&
-          isPositive(compare(left, right, options)))
-      ) {
-        context.report({
-          messageId,
-          data: {
-            left: toSingleLine(left.name),
-            right: toSingleLine(right.name),
-          },
-          node: right.node,
-          fix: fixer => {
-            let sortedNodes =
-              options.groupKind !== 'mixed'
-                ? groupKindOrder
-                    .map(group => nodes.filter(n => n.group === group))
-                    .map(groupedNodes => sortNodes(groupedNodes, options))
-                    .flat()
-                : sortNodes(nodes, options)
-
-            return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
-              partitionComment,
-            })
-          },
-        })
-      }
-    })
+              return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                partitionComment,
+              })
+            },
+          })
+        }
+      })
+    }
   }
 }

--- a/rules/sort-imports.ts
+++ b/rules/sort-imports.ts
@@ -558,8 +558,10 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
 
             fixes.push(
               fixer.replaceTextRange(
-                getNodeRange(nodesToFix.at(i)!.node, sourceCode),
-                sourceCode.text.slice(...getNodeRange(node.node, sourceCode)),
+                getNodeRange(nodesToFix.at(i)!.node, sourceCode, false),
+                sourceCode.text.slice(
+                  ...getNodeRange(node.node, sourceCode, false),
+                ),
               ),
             )
 
@@ -583,10 +585,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 ) {
                   fixes.push(
                     fixer.removeRange([
-                      getNodeRange(nodesToFix.at(i)!.node, sourceCode).at(1)!,
-                      getNodeRange(nodesToFix.at(i + 1)!.node, sourceCode).at(
-                        0,
-                      )! - 1,
+                      getNodeRange(
+                        nodesToFix.at(i)!.node,
+                        sourceCode,
+                        false,
+                      ).at(1)!,
+                      getNodeRange(
+                        nodesToFix.at(i + 1)!.node,
+                        sourceCode,
+                        false,
+                      ).at(0)! - 1,
                     ]),
                   )
                 }
@@ -600,10 +608,16 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   fixes.push(
                     fixer.replaceTextRange(
                       [
-                        getNodeRange(nodesToFix.at(i)!.node, sourceCode).at(1)!,
-                        getNodeRange(nodesToFix.at(i + 1)!.node, sourceCode).at(
-                          0,
-                        )! - 1,
+                        getNodeRange(
+                          nodesToFix.at(i)!.node,
+                          sourceCode,
+                          false,
+                        ).at(1)!,
+                        getNodeRange(
+                          nodesToFix.at(i + 1)!.node,
+                          sourceCode,
+                          false,
+                        ).at(0)! - 1,
                       ],
                       '\n',
                     ),
@@ -618,7 +632,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                 ) {
                   fixes.push(
                     fixer.insertTextAfterRange(
-                      getNodeRange(nodesToFix.at(i)!.node, sourceCode),
+                      getNodeRange(nodesToFix.at(i)!.node, sourceCode, false),
                       '\n',
                     ),
                   )

--- a/rules/sort-object-types.ts
+++ b/rules/sort-object-types.ts
@@ -3,6 +3,8 @@ import type { TSESTree } from '@typescript-eslint/types'
 import type { SortingNode } from '../typings'
 
 import { validateGroupsConfiguration } from '../utils/validate-groups-configuration'
+import { hasPartitionComment } from '../utils/is-partition-comment'
+import { getCommentsBefore } from '../utils/get-comments-before'
 import { createEslintRule } from '../utils/create-eslint-rule'
 import { getLinesBetween } from '../utils/get-lines-between'
 import { getGroupNumber } from '../utils/get-group-number'
@@ -29,12 +31,15 @@ type Options<T extends string[]> = [
     groupKind: 'required-first' | 'optional-first' | 'mixed'
     customGroups: { [key in T[number]]: string[] | string }
     type: 'alphabetical' | 'line-length' | 'natural'
+    partitionByComment: string[] | boolean | string
     groups: (Group<T>[] | Group<T>)[]
     partitionByNewLine: boolean
     order: 'desc' | 'asc'
     ignoreCase: boolean
   }>,
 ]
+
+type SortObjectTypesSortingNode = SortingNode<TSESTree.TypeElement>
 
 export default createEslintRule<Options<string[]>, MESSAGE_ID>({
   name: 'sort-object-types',
@@ -63,6 +68,24 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
             description:
               'Controls whether sorting should be case-sensitive or not.',
             type: 'boolean',
+          },
+          partitionByComment: {
+            description:
+              'Allows you to use comments to separate the class members into logical groups.',
+            anyOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+              {
+                type: 'boolean',
+              },
+              {
+                type: 'string',
+              },
+            ],
           },
           partitionByNewLine: {
             description:
@@ -124,6 +147,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
       type: 'alphabetical',
       order: 'asc',
       ignoreCase: true,
+      partitionByComment: false,
       partitionByNewLine: false,
       groupKind: 'mixed',
       groups: [],
@@ -136,6 +160,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         let settings = getSettings(context.settings)
 
         let options = complete(context.options.at(0), settings, {
+          partitionByComment: false,
           partitionByNewLine: false,
           type: 'alphabetical',
           groupKind: 'mixed',
@@ -152,16 +177,17 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
         )
 
         let sourceCode = getSourceCode(context)
+        let partitionComment = options.partitionByComment
 
-        let formattedMembers: SortingNode<TSESTree.TypeElement>[][] =
+        let formattedMembers: SortObjectTypesSortingNode[][] =
           node.members.reduce(
-            (accumulator: SortingNode<TSESTree.TypeElement>[][], member) => {
+            (accumulator: SortObjectTypesSortingNode[][], member) => {
               let name: string
               let raw = sourceCode.text.slice(
                 member.range.at(0),
                 member.range.at(1),
               )
-              let lastMember = accumulator.at(-1)?.at(-1)
+              let lastSortingNode = accumulator.at(-1)?.at(-1)
 
               let { getGroup, defineGroup, setCustomGroups } = useGroups(
                 options.groups,
@@ -203,24 +229,27 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
               let endsWithComma = raw.endsWith(';') || raw.endsWith(',')
               let endSize = endsWithComma ? 1 : 0
 
-              let memberSortingNode = {
+              let sortingNode: SortObjectTypesSortingNode = {
                 size: rangeToDiff(member.range) - endSize,
+                group: getGroup(),
                 node: member,
                 name,
               }
 
               if (
-                options.partitionByNewLine &&
-                lastMember &&
-                getLinesBetween(sourceCode, lastMember, memberSortingNode)
+                (partitionComment &&
+                  hasPartitionComment(
+                    partitionComment,
+                    getCommentsBefore(member, sourceCode),
+                  )) ||
+                (options.partitionByNewLine &&
+                  lastSortingNode &&
+                  getLinesBetween(sourceCode, lastSortingNode, sortingNode))
               ) {
                 accumulator.push([])
               }
 
-              accumulator.at(-1)?.push({
-                ...memberSortingNode,
-                group: getGroup(),
-              })
+              accumulator.at(-1)?.push(sortingNode)
 
               return accumulator
             },
@@ -296,7 +325,7 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                   let groupedByKind
                   if (options.groupKind !== 'mixed') {
                     groupedByKind = nodes.reduce<
-                      SortingNode<TSESTree.TypeElement>[][]
+                      SortObjectTypesSortingNode[][]
                     >(
                       (accumulator, currentNode) => {
                         let requiredIndex =
@@ -344,7 +373,9 @@ export default createEslintRule<Options<string[]>, MESSAGE_ID>({
                     }
                   }
 
-                  return makeFixes(fixer, nodes, sortedNodes, sourceCode)
+                  return makeFixes(fixer, nodes, sortedNodes, sourceCode, {
+                    partitionComment,
+                  })
                 },
               })
             }

--- a/rules/sort-objects.ts
+++ b/rules/sort-objects.ts
@@ -378,7 +378,6 @@ export default createEslintRule<Options, MESSAGE_ID>({
               }
 
               let comments = getCommentsBefore(prop, sourceCode)
-              let lastProp = accumulator.at(-1)?.at(-1)
 
               if (
                 options.partitionByComment &&
@@ -407,10 +406,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
                 name,
               }
 
+              let lastSortingNode = accumulator.at(-1)?.at(-1)
               if (
                 options.partitionByNewLine &&
-                lastProp &&
-                getLinesBetween(sourceCode, lastProp, propSortingNode)
+                lastSortingNode &&
+                getLinesBetween(sourceCode, lastSortingNode, propSortingNode)
               ) {
                 accumulator.push([])
               }

--- a/test/sort-array-includes.test.ts
+++ b/test/sort-array-includes.test.ts
@@ -1266,5 +1266,57 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              [
+                'd',
+                'a',
+
+                'c',
+
+                'e',
+                'b',
+              ].includes(value)
+            `,
+          output: dedent`
+              [
+                'a',
+                'd',
+
+                'c',
+
+                'b',
+                'e',
+              ].includes(value)
+            `,
+          options: [
+            {
+              type: 'alphabetical',
+              partitionByNewLine: true,
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedArrayIncludesOrder',
+              data: {
+                left: 'd',
+                right: 'a',
+              },
+            },
+            {
+              messageId: 'unexpectedArrayIncludesOrder',
+              data: {
+                left: 'e',
+                right: 'b',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 })

--- a/test/sort-enums.test.ts
+++ b/test/sort-enums.test.ts
@@ -1977,12 +1977,15 @@ describe(ruleName, () => {
       )
     })
 
-    describe('handles complex comment cases', () => {
-      ruleTester.run(`keeps comments associated to their node`, rule, {
-        valid: [],
-        invalid: [
-          {
-            code: dedent`
+    describe(`${ruleName}: handles complex comment cases`, () => {
+      ruleTester.run(
+        `${ruleName}: keeps comments associated to their node`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
               enum Enum {
                 // Ignore this comment
 
@@ -2002,7 +2005,7 @@ describe(ruleName, () => {
                 A = 'A',
               }
             `,
-            output: dedent`
+              output: dedent`
               enum Enum {
                 // Ignore this comment
 
@@ -2022,25 +2025,26 @@ describe(ruleName, () => {
                 B = 'B',
               }
             `,
-            options: [
-              {
-                type: 'alphabetical',
-              },
-            ],
-            errors: [
-              {
-                messageId: 'unexpectedEnumsOrder',
-                data: {
-                  left: 'B',
-                  right: 'A',
+              options: [
+                {
+                  type: 'alphabetical',
                 },
-              },
-            ],
-          },
-        ],
-      })
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedEnumsOrder',
+                  data: {
+                    left: 'B',
+                    right: 'A',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
 
-      ruleTester.run(`handles partition comments`, rule, {
+      ruleTester.run(`${ruleName}: handles partition comments`, rule, {
         valid: [],
         invalid: [
           {
@@ -2119,6 +2123,58 @@ describe(ruleName, () => {
           },
         ],
       })
+    })
+
+    ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+            enum Enum {
+              D = 'D',
+              C = 'C',
+
+              B = 'B',
+
+              E = 'E',
+              A = 'A',
+            }
+          `,
+          output: dedent`
+            enum Enum {
+              C = 'C',
+              D = 'D',
+
+              B = 'B',
+
+              A = 'A',
+              E = 'E',
+            }
+          `,
+          options: [
+            {
+              type: 'alphabetical',
+              partitionByNewLine: true,
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'D',
+                right: 'C',
+              },
+            },
+            {
+              messageId: 'unexpectedEnumsOrder',
+              data: {
+                left: 'E',
+                right: 'A',
+              },
+            },
+          ],
+        },
+      ],
     })
   })
 })

--- a/test/sort-interfaces.test.ts
+++ b/test/sort-interfaces.test.ts
@@ -660,6 +660,153 @@ describe(ruleName, () => {
       },
     )
 
+    describe('partition comments', () => {
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use partition comments`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              interface Interface {
+                // Part: A
+                cc: string
+                d: string
+                // Not partition comment
+                bbb: string
+                // Part: B
+                aaaa: string
+                e: string
+                // Part: C
+                'gg': string
+                // Not partition comment
+                fff: string
+              }
+            `,
+              output: dedent`
+              interface Interface {
+                // Part: A
+                // Not partition comment
+                bbb: string
+                cc: string
+                d: string
+                // Part: B
+                aaaa: string
+                e: string
+                // Part: C
+                // Not partition comment
+                fff: string
+                'gg': string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: 'Part**',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                  data: {
+                    left: 'd',
+                    right: 'bbb',
+                  },
+                },
+                {
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                  data: {
+                    left: 'gg',
+                    right: 'fff',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              interface Interface {
+                // Comment
+                bb: string
+                // Other comment
+                a: string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: true,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              interface Interface {
+                /* Partition Comment */
+                // Part: A
+                d: string
+                // Part: B
+                aaa: string
+                c: string
+                bb: string
+                /* Other */
+                e: string
+              }
+            `,
+              output: dedent`
+              interface Interface {
+                /* Partition Comment */
+                // Part: A
+                d: string
+                // Part: B
+                aaa: string
+                bb: string
+                c: string
+                /* Other */
+                e: string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedInterfacePropertiesOrder',
+                  data: {
+                    left: 'c',
+                    right: 'bb',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
+
     ruleTester.run(`${ruleName}(${type}): sorts interface properties`, rule, {
       valid: [
         {

--- a/test/sort-object-types.test.ts
+++ b/test/sort-object-types.test.ts
@@ -481,6 +481,153 @@ describe(ruleName, () => {
       },
     )
 
+    describe('partition comments', () => {
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use partition comments`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              type Type = {
+                // Part: A
+                cc: string
+                d: string
+                // Not partition comment
+                bbb: string
+                // Part: B
+                aaaa: string
+                e: string
+                // Part: C
+                'gg': string
+                // Not partition comment
+                fff: string
+              }
+            `,
+              output: dedent`
+              type Type = {
+                // Part: A
+                // Not partition comment
+                bbb: string
+                cc: string
+                d: string
+                // Part: B
+                aaaa: string
+                e: string
+                // Part: C
+                // Not partition comment
+                fff: string
+                'gg': string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: 'Part**',
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedObjectTypesOrder',
+                  data: {
+                    left: 'd',
+                    right: 'bbb',
+                  },
+                },
+                {
+                  messageId: 'unexpectedObjectTypesOrder',
+                  data: {
+                    left: 'gg',
+                    right: 'fff',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use all comments as parts`,
+        rule,
+        {
+          valid: [
+            {
+              code: dedent`
+              type Type = {
+                // Comment
+                bb: string
+                // Other comment
+                a: string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: true,
+                },
+              ],
+            },
+          ],
+          invalid: [],
+        },
+      )
+
+      ruleTester.run(
+        `${ruleName}(${type}): allows to use multiple partition comments`,
+        rule,
+        {
+          valid: [],
+          invalid: [
+            {
+              code: dedent`
+              type Type = {
+                /* Partition Comment */
+                // Part: A
+                d: string
+                // Part: B
+                aaa: string
+                c: string
+                bb: string
+                /* Other */
+                e: string
+              }
+            `,
+              output: dedent`
+              type Type = {
+                /* Partition Comment */
+                // Part: A
+                d: string
+                // Part: B
+                aaa: string
+                bb: string
+                c: string
+                /* Other */
+                e: string
+              }
+            `,
+              options: [
+                {
+                  ...options,
+                  partitionByComment: ['Partition Comment', 'Part: *', 'Other'],
+                },
+              ],
+              errors: [
+                {
+                  messageId: 'unexpectedObjectTypesOrder',
+                  data: {
+                    left: 'c',
+                    right: 'bb',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      )
+    })
+
     ruleTester.run(
       `${ruleName}(${type}): allows to sort required values first`,
       rule,

--- a/test/sort-objects.test.ts
+++ b/test/sort-objects.test.ts
@@ -2069,7 +2069,7 @@ describe(ruleName, () => {
             `,
             options: [
               {
-                type: 'alphabetical',
+                ...options,
                 order: 'asc',
               },
             ],
@@ -2904,7 +2904,7 @@ describe(ruleName, () => {
             `,
             options: [
               {
-                type: 'alphabetical',
+                ...options,
                 order: 'asc',
               },
             ],

--- a/test/sort-sets.test.ts
+++ b/test/sort-sets.test.ts
@@ -1213,5 +1213,57 @@ describe(ruleName, () => {
       ],
       invalid: [],
     })
+
+    ruleTester.run(`${ruleName}: allows to use new line as partition`, rule, {
+      valid: [],
+      invalid: [
+        {
+          code: dedent`
+              new Set([
+                'd',
+                'a',
+
+                'c',
+
+                'e',
+                'b',
+              ])
+            `,
+          output: dedent`
+              new Set([
+                'a',
+                'd',
+
+                'c',
+
+                'b',
+                'e',
+              ])
+            `,
+          options: [
+            {
+              type: 'alphabetical',
+              partitionByNewLine: true,
+            },
+          ],
+          errors: [
+            {
+              messageId: 'unexpectedSetsOrder',
+              data: {
+                left: 'd',
+                right: 'a',
+              },
+            },
+            {
+              messageId: 'unexpectedSetsOrder',
+              data: {
+                left: 'e',
+                right: 'b',
+              },
+            },
+          ],
+        },
+      ],
+    })
   })
 })

--- a/test/sort-switch-case.test.ts
+++ b/test/sort-switch-case.test.ts
@@ -531,6 +531,64 @@ describe(ruleName, () => {
         ],
       },
     )
+
+    ruleTester.run(
+      `${ruleName}(${type}): allows to use new line as partition`,
+      rule,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: dedent`
+              switch (x) {
+                case 'd':
+                case 'a':
+
+                case 'c':
+
+                case 'e':
+                case 'b':
+                   break
+              }
+            `,
+            output: dedent`
+              switch (x) {
+                case 'a':
+                case 'd':
+
+                case 'c':
+
+                case 'b':
+                case 'e':
+                   break
+              }
+            `,
+            options: [
+              {
+                ...options,
+                partitionByNewLine: true,
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'd',
+                  right: 'a',
+                },
+              },
+              {
+                messageId: 'unexpectedSwitchCaseOrder',
+                data: {
+                  left: 'e',
+                  right: 'b',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    )
   })
 
   describe(`${ruleName}: sorting by natural order`, () => {

--- a/utils/get-node-range.ts
+++ b/utils/get-node-range.ts
@@ -9,9 +9,7 @@ import { getCommentsBefore } from './get-comments-before'
 export let getNodeRange = (
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
-  additionalOptions?: {
-    partitionComment?: string[] | boolean | string
-  },
+  partitionComment: string[] | boolean | string,
 ): TSESTree.Range => {
   let start = node.range.at(0)!
   let end = node.range.at(1)!

--- a/utils/make-fixes.ts
+++ b/utils/make-fixes.ts
@@ -23,11 +23,12 @@ export let makeFixes = (
   for (let max = nodes.length, i = 0; i < max; i++) {
     let { node } = nodes.at(i)!
 
+    let partitionComment = additionalOptions?.partitionComment ?? false
     fixes.push(
       fixer.replaceTextRange(
-        getNodeRange(node, source, additionalOptions),
+        getNodeRange(node, source, partitionComment),
         source.text.slice(
-          ...getNodeRange(sortedNodes.at(i)!.node, source, additionalOptions),
+          ...getNodeRange(sortedNodes.at(i)!.node, source, partitionComment),
         ),
       ),
     )


### PR DESCRIPTION
- sort-array-includes: partitionByNewLine + partitionByComment
- sort-sets: partitionByNewLine + partitionByComment
- sort-maps: partitionByNewLine + partitionByComment
- sort-enums: partitionByNewLine (todo: fix sortNodesByDependencies side effect)
- sort-interfaces: partitionByComment
- sort-object-types: partitionByComment
- sort-objects: partitionByNewLine
- sort-intersection-types: partitionByNewline + partitionByComment (investigate & token before element not detecting comments)
- sort-union-types: partitionByNewLine + partitionByComment (investigate | token before element not detecting comments)
- sort-switch-case: partitionByNewLine (partitionByComment requires too many changes)
- sort-named-exports: partitionByNewLine + partitionByComment
- sort-named-imports: partitionByNewLine + partitionByComment

Todo
sort-variable-declarations?