### PR TITLE
feat: adds `customGroups.newlinesAbove` and `customGroups.newlinesBelow`

### DIFF
--- a/rules/sort-classes/types.ts
+++ b/rules/sort-classes/types.ts
@@ -36,7 +36,12 @@ export type SingleCustomGroup =
   | BaseSingleCustomGroup<ConstructorSelector>
   | AdvancedSingleCustomGroup<MethodSelector>
 
-export type CustomGroup = (
+export type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
   | {
       order?: SortClassesOptions[0]['order']
       type?: SortClassesOptions[0]['type']
@@ -44,10 +49,8 @@ export type CustomGroup = (
   | {
       type?: 'unsorted'
     }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
+) &
+  (SingleCustomGroup | AnyOfCustomGroup)
 
 export type NonDeclarePropertyGroup = JoinWithDash<
   [

--- a/rules/sort-modules/types.ts
+++ b/rules/sort-modules/types.ts
@@ -67,7 +67,12 @@ interface AllowedModifiersPerSelector {
   type: DeclareModifier | ExportModifier
 }
 
-type CustomGroup = (
+type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
   | {
       order?: SortModulesOptions[0]['order']
       type?: SortModulesOptions[0]['type']
@@ -75,10 +80,8 @@ type CustomGroup = (
   | {
       type?: 'unsorted'
     }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
+) &
+  (SingleCustomGroup | AnyOfCustomGroup)
 /**
  * Only used in code, so I don't know if it's worth maintaining this.
  */

--- a/rules/sort-object-types/types.ts
+++ b/rules/sort-object-types/types.ts
@@ -56,6 +56,22 @@ export interface AnyOfCustomGroup {
   anyOf: SingleCustomGroup[]
 }
 
+type CustomGroup = {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+} & (
+  | {
+      order?: Options[0]['order']
+      type?: Options[0]['type']
+    }
+  | {
+      type?: 'unsorted'
+    }
+) &
+  (SingleCustomGroup | AnyOfCustomGroup)
+
 /**
  * Only used in code as well
  */
@@ -66,19 +82,6 @@ interface AllowedModifiersPerSelector {
   multiline: OptionalModifier | RequiredModifier
   'index-signature': never
 }
-
-type CustomGroup = (
-  | {
-      order?: Options[0]['order']
-      type?: Options[0]['type']
-    }
-  | {
-      type?: 'unsorted'
-    }
-) & {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
-} & (SingleCustomGroup | AnyOfCustomGroup)
 
 type IndexSignatureGroup = JoinWithDash<
   [

--- a/test/get-newlines-between-option.test.ts
+++ b/test/get-newlines-between-option.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest'
+
+import type { GetNewlinesBetweenOptionParameters } from '../utils/get-newlines-between-option'
+import type { SortingNode } from '../types/sorting-node'
+
+import { getNewlinesBetweenOption } from '../utils/get-newlines-between-option'
+
+describe('get-newlines-between-option', () => {
+  describe('global "newlinesBetween" option', () => {
+    it('should return the global option if "customGroups" is not defined', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return the global option if "customGroups" is not an array', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+            customGroups: {},
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return "ignore" if "newlinesBetween" is "ignore"', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'ignore',
+          }),
+        ),
+      ).toBe('ignore')
+    })
+
+    it('should return "never" if "newlinesBetween" is "never"', () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+
+    it('should return "always" if "newlinesBetween" is "always" and nodeGroupNumber !== nextNodeGroupNumber', () => {
+      expect(
+        getNewlinesBetweenOption({
+          options: {
+            groups: ['group1', 'group2'],
+            newlinesBetween: 'always',
+          },
+          nextSortingNode: generateSortingNodeWithGroup('group1'),
+          sortingNode: generateSortingNodeWithGroup('group2'),
+        }),
+      ).toBe('always')
+    })
+
+    it('should return "never" if "newlinesBetween" is "always" and nodeGroupNumber === nextNodeGroupNumber', () => {
+      expect(
+        getNewlinesBetweenOption({
+          options: {
+            newlinesBetween: 'always',
+            groups: ['group1'],
+          },
+          nextSortingNode: generateSortingNodeWithGroup('group1'),
+          sortingNode: generateSortingNodeWithGroup('group1'),
+        }),
+      ).toBe('never')
+    })
+
+    it("should return the global option if the node's group is within an array", () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            customGroups: [
+              {
+                groupName: 'group1',
+              },
+            ],
+            groups: [['group1', 'group3'], 'group2'],
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+
+    it("should return the global option if the next node's group is within an array", () => {
+      expect(
+        getNewlinesBetweenOption(
+          buildParameters({
+            customGroups: [
+              {
+                groupName: 'group1',
+              },
+            ],
+            groups: ['group1', ['group2', 'group3']],
+            newlinesBetween: 'never',
+          }),
+        ),
+      ).toBe('never')
+    })
+  })
+
+  describe('custom groups "newlinesBetween" option', () => {
+    describe('when the node and next node belong to the same custom group', () => {
+      let parameters = {
+        customGroups: [
+          {
+            newlinesInside: 'always',
+            groupName: 'group1',
+          },
+        ],
+        nextSortingNodeGroup: 'group1',
+        sortingNodeGroup: 'group1',
+        newlinesBetween: 'never',
+      } as const
+
+      it('should return the "newlinesInside" option if defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              ...parameters,
+              customGroups: [
+                {
+                  newlinesInside: 'always',
+                  groupName: 'group1',
+                },
+              ],
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the global option if the "newlinesInside" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              ...parameters,
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+              ],
+            }),
+          ),
+        ).toBe('never')
+      })
+    })
+
+    describe('when the node and next node do not belong to the same custom group', () => {
+      it('should return the global option if the node "newlinesBelow" option is not defined and the next node "newlinesAbove" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+                {
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('never')
+      })
+
+      it('should return the next node "newlinesAbove" option if the node option "newlinesBelow" is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the next node "newlinesAbove" option if the node option "newlinesBelow" is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the node option "newlinesBelow" if the next node "newlinesAbove" option is not defined', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return the node option "newlinesBelow" if the next node "newlinesAbove" option is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "ignore" if the node "newlinesAbove" option is "always" and the next node "newlinesBelow" is "never"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'never',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('ignore')
+      })
+
+      it('should return "ignore" if the node "newlinesAbove" option is "never" and the next node "newlinesBelow" is "always"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'never',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('ignore')
+      })
+
+      it('should return "always" if the node "newlinesAbove" option is "always" and the next node "newlinesBelow" is "ignore"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'ignore',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'always',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "always" if the node "newlinesAbove" option is "ignore" and the next node "newlinesBelow" is "always"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'always',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'ignore',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('always')
+      })
+
+      it('should return "never" if the node "newlinesAbove" option and the next node "newlinesBelow" option is "never"', () => {
+        expect(
+          getNewlinesBetweenOption(
+            buildParameters({
+              customGroups: [
+                {
+                  newlinesBelow: 'never',
+                  groupName: 'group1',
+                },
+                {
+                  newlinesAbove: 'never',
+                  groupName: 'group2',
+                },
+              ],
+              newlinesBetween: 'never',
+            }),
+          ),
+        ).toBe('never')
+      })
+    })
+  })
+
+  let buildParameters = ({
+    nextSortingNodeGroup,
+    sortingNodeGroup,
+    newlinesBetween,
+    customGroups,
+    groups,
+  }: {
+    newlinesBetween: GetNewlinesBetweenOptionParameters['options']['newlinesBetween']
+    customGroups?: GetNewlinesBetweenOptionParameters['options']['customGroups']
+    groups?: GetNewlinesBetweenOptionParameters['options']['groups']
+    nextSortingNodeGroup?: string
+    sortingNodeGroup?: string
+  }): GetNewlinesBetweenOptionParameters => ({
+    options: {
+      groups: groups ?? ['group1', 'group2'],
+      newlinesBetween,
+      customGroups,
+    },
+    nextSortingNode: generateSortingNodeWithGroup(
+      nextSortingNodeGroup ?? 'group2',
+    ),
+    sortingNode: generateSortingNodeWithGroup(sortingNodeGroup ?? 'group1'),
+  })
+
+  let generateSortingNodeWithGroup = (group: string): SortingNode =>
+    ({
+      group,
+    }) as SortingNode
+})

--- a/utils/common-json-schemas.ts
+++ b/utils/common-json-schemas.ts
@@ -162,6 +162,24 @@ let customGroupNewlinesInsideJsonSchema: Record<string, JSONSchema4> = {
   },
 }
 
+let customGroupNewlinesAboveJsonSchema: Record<string, JSONSchema4> = {
+  newlinesAbove: {
+    description:
+      'Specifies how new lines should be handled right above the custom group.',
+    enum: ['ignore', 'always', 'never'],
+    type: 'string',
+  },
+}
+
+let customGroupNewlinesBelowJsonSchema: Record<string, JSONSchema4> = {
+  newlinesBelow: {
+    description:
+      'Specifies how new lines should be handled right below the custom group.',
+    enum: ['ignore', 'always', 'never'],
+    type: 'string',
+  },
+}
+
 export let buildCustomGroupsArrayJsonSchema = ({
   singleCustomGroupJsonSchema,
 }: {
@@ -173,7 +191,9 @@ export let buildCustomGroupsArrayJsonSchema = ({
         properties: {
           ...customGroupNameJsonSchema,
           ...customGroupSortJsonSchema,
+          ...customGroupNewlinesAboveJsonSchema,
           ...customGroupNewlinesInsideJsonSchema,
+          ...customGroupNewlinesBelowJsonSchema,
           anyOf: {
             items: {
               properties: {
@@ -194,7 +214,9 @@ export let buildCustomGroupsArrayJsonSchema = ({
         properties: {
           ...customGroupNameJsonSchema,
           ...customGroupSortJsonSchema,
+          ...customGroupNewlinesAboveJsonSchema,
           ...customGroupNewlinesInsideJsonSchema,
+          ...customGroupNewlinesBelowJsonSchema,
           ...singleCustomGroupJsonSchema,
         },
         description: 'Custom group.',

--- a/utils/get-newlines-errors.ts
+++ b/utils/get-newlines-errors.ts
@@ -21,6 +21,8 @@ interface GetNewlinesErrorsParameters<T extends string> {
 }
 
 interface CustomGroup {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
   newlinesInside?: 'always' | 'never'
   groupName: string
 }

--- a/utils/make-newlines-fixes.ts
+++ b/utils/make-newlines-fixes.ts
@@ -6,6 +6,13 @@ import { getNewlinesBetweenOption } from './get-newlines-between-option'
 import { getLinesBetween } from './get-lines-between'
 import { getNodeRange } from './get-node-range'
 
+interface CustomGroup {
+  newlinesAbove?: 'ignore' | 'always' | 'never'
+  newlinesBelow?: 'ignore' | 'always' | 'never'
+  newlinesInside?: 'always' | 'never'
+  groupName: string
+}
+
 interface MakeNewlinesFixesParameters {
   sourceCode: TSESLint.SourceCode
   sortedNodes: SortingNode[]
@@ -18,11 +25,6 @@ interface Options {
   customGroups?: Record<string, string[] | string> | CustomGroup[]
   newlinesBetween: 'ignore' | 'always' | 'never'
   groups: (string[] | string)[]
-}
-
-interface CustomGroup {
-  newlinesInside?: 'always' | 'never'
-  groupName: string
 }
 
 export let makeNewlinesFixes = ({


### PR DESCRIPTION
Resolves #401
Continuation of #428.

- ✅ **PR 1**: Add `customGroup.newlinesInside` option. We will take the opportunity to create a `getNewlinesBetweenOption` method that will help us later to precisely customize newline behavior between two specific groups. 
- ⚙️ **PR 2 (this)**: Add a way to choose a specific newline behavior between two groups. See the proposals [here](https://github.com/azat-io/eslint-plugin-perfectionist/issues/401#issuecomment-2558581331).
  - Proposal **1** is implemented here.

# Description

We currently have the `newlinesBetween` option, which applies the same newlines-related rules between all groups.
This PR adds 2 sub-options for the new array-based `customGroups`:
- `newlinesAbove?: 'ignore' | 'always' | 'never'`
- `newlinesBelow?: 'ignore' | 'always' | 'never' `

Here is the list of rules with this new addition:
- `sort-classes`
- `sort-modules`
- `sort-object-types`
- `sort-interfaces`

# Options

## `customGroup.newlinesBelow?: 'ignore' | 'always' | 'never'`

Newlines rule that should be applied between a node of the custom group THEN a node of a **different** group.

See example under.

## `customGroup.newlinesAbove?: 'ignore' | 'always' | 'never'`

Newlines rule that should be applied between a node of a **different** group THEN a node of the custom group.

Example: Enforce separating class properties and methods with a newline, but public, protected and private properties should not have newlines between them.
```ts
{
  groups: ["public-properties", "protected-properties", "private-properties", "methods"],
  customGroups: [
    {
      groupName: "public-properties",
      selector: "property",
      modifier: "public",
      newlinesBelow: "never"
    },
    {
      groupName: "protected-properties",
      selector: "property",
      modifier: "protected",
      newlinesBelow: "never"
    },
    {
      groupName: "private-properties",
      selector: "property",
      modifier: "private",
      newlinesBelow: "always"
    },
    {
      groupName: "methods",
      selector: "method",
      // newlinesAbove: "always" - This is useless as the `private-properties` custom group defines `newlinesBelow` already
    },
  ]
}
```

## List of newlines-related behaviors between two consecutive nodes 

Let's take two sorted nodes **node1** (`group1`)  before (above) **node2** (`group2`).
The three possible newline behaviors are:
- `ignore`: Don't enforce anything.
- `always`: Enforce a single line between the two nodes.
- `never`: Enforce no newline between the two nodes.

The "global" `options.newlinesBetween` option coexist with custom groups `newlinesBetween`, `newlinesAbove` and `newlinesBelow` in the following ways:

- If `options.customGroups` is `undefined`, `options.newlinesBetween` takes priority.
- If `options.customGroups` is not an array (new API), `options.newlinesBetween` takes priority.
- If one of the groups (`group1` or `group2`) is within an array in `options.groups`, `options.newlinesBetween` takes priority.
- If `node1` and `node2` belong to the same custom group `group1`:
  -  If `group1.newlinesInside` is defined, it takes priority.
  -  If `group1.newlinesInside` is `undefined`, `options.newlinesBetween` takes priority.
- If `node1` and `node2` do NOT belong to the **same** custom group:
  - if `group1` is not a custom group, or if `group1.newlinesBelow` is `💤 ignore` or `undefined`, `group2.newlinesAbove` takes priority.
  - if `group2` is not a custom group, or if `group2.newlinesAbove` is `💤  ignore` or `undefined`, `group1.newlinesBelow` takes priority.
  - if both `group1` and `group2` are not custom groups, or if `group1.newlinesBelow` and `group2.newlinesAbove` are both `undefined`, `options.newlinesBetween` takes priority.
  - if both `group1.newlinesBelow` and `group2.newlinesAbove` are `❌ never`, the chosen behavior will be `❌ never`.
  - if both `group1.newlinesBelow` and `group2.newlinesAbove` are `✅ always`, the chosen behavior will be `✅ always`.
  - if `group1.newlinesBelow` is `✅ always` and `group2.newlinesAbove` is `❌ never`, or the opposite, the chosen behavior will be `💤 ignore`.

### What is the purpose of this pull request?

- [x] New Feature